### PR TITLE
feat: externalize Google Maps API key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+package-lock.json
+assets/config.js
+*.DS_Store

--- a/assets/config.example.js
+++ b/assets/config.example.js
@@ -1,0 +1,2 @@
+// Copy this file to config.js and set your Google Maps API key
+const GOOGLE_MAPS_API_KEY = "YOUR_API_KEY_HERE";

--- a/assets/map.js
+++ b/assets/map.js
@@ -1,10 +1,22 @@
+(function() {
+  if (typeof GOOGLE_MAPS_API_KEY === 'undefined' || !GOOGLE_MAPS_API_KEY) {
+    console.error('Google Maps API key not set. Please create assets/config.js with your key.');
+    return;
+  }
+  const script = document.createElement('script');
+  script.src = `https://maps.googleapis.com/maps/api/js?key=${GOOGLE_MAPS_API_KEY}&callback=initMap`;
+  script.async = true;
+  script.defer = true;
+  document.head.appendChild(script);
+})();
+
 function initMap() {
-  const map = new google.maps.Map(document.getElementById("map"), {
+  const map = new google.maps.Map(document.getElementById('map'), {
     zoom: 7,
-    center: { lat: 40.2732, lng: -76.8867 } // center on Pennsylvania
+    center: { lat: 40.2732, lng: -76.8867 }
   });
 
-  fetch("assets/locations.json")
+  fetch('assets/locations.json')
     .then(response => response.json())
     .then(data => {
       data.forEach(loc => {
@@ -15,5 +27,7 @@ function initMap() {
         });
       });
     })
-    .catch(err => console.error("Error loading locations:", err));
+    .catch(err => console.error('Error loading locations:', err));
 }
+
+window.initMap = initMap;

--- a/map.html
+++ b/map.html
@@ -6,8 +6,7 @@
   <title>Shoofly Map</title>
   <link href="https://fonts.googleapis.com/css2?family=Rubik:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/style.css" />
-  <!-- Google Maps JS API -->
-  <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCwvqpPxd8wHd5VjN7nO4cD-IYWUQrH6xo"></script>
+  <!-- Google Maps API key is provided via assets/config.js -->
 </head>
 <body>
   <main>
@@ -36,6 +35,7 @@
     &copy; 2025 findshoofly.com. All rights reserved.
   </footer>
 
+  <script src="assets/config.js"></script>
   <script src="assets/map.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load Google Maps API key from an ignored `assets/config.js`
- dynamically inject Maps script once key is present
- add config template and gitignore entries for sensitive files

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689a64b1dad88332a3e94106b4a5549c