### PR TITLE
feat: externalize Google Maps API key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+package-lock.json
+assets/config.js
+*.DS_Store

--- a/assets/config.example.js
+++ b/assets/config.example.js
@@ -1,0 +1,2 @@
+// Copy this file to config.js and set your Google Maps API key
+const GOOGLE_MAPS_API_KEY = "YOUR_API_KEY_HERE";

--- a/assets/map.js
+++ b/assets/map.js
@@ -1,10 +1,22 @@
+(function() {
+  if (typeof GOOGLE_MAPS_API_KEY === 'undefined' || !GOOGLE_MAPS_API_KEY) {
+    console.error('Google Maps API key not set. Please create assets/config.js with your key.');
+    return;
+  }
+  const script = document.createElement('script');
+  script.src = `https://maps.googleapis.com/maps/api/js?key=${GOOGLE_MAPS_API_KEY}&callback=initMap`;
+  script.async = true;
+  script.defer = true;
+  document.head.appendChild(script);
+})();
+
 function initMap() {
-  const map = new google.maps.Map(document.getElementById("map"), {
+  const map = new google.maps.Map(document.getElementById('map'), {
     zoom: 7,
-    center: { lat: 40.2732, lng: -76.8867 } // center on Pennsylvania
+    center: { lat: 40.2732, lng: -76.8867 }
   });
 
-  fetch("assets/locations.json")
+  fetch('assets/locations.json')
     .then(response => response.json())
     .then(data => {
       data.forEach(loc => {
@@ -15,5 +27,7 @@ function initMap() {
         });
       });
     })
-    .catch(err => console.error("Error loading locations:", err));
+    .catch(err => console.error('Error loading locations:', err));
 }
+
+window.initMap = initMap;

--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
 
     <section class="section">
       <h2>History of Shoofly Pie</h2>
-      <img src="assets/pa-dutch.jpg" alt="Pennsylvania Dutch Country" class="section-img">
+      <img src="assets/pa-dutch-county.png" alt="Pennsylvania Dutch Country" class="section-img">
       <p>The dessert dates back to the late 1800s, when it was often served for breakfast with coffee. Its name comes from the need to “shoo” flies away from its sweet filling. Today, shoofly pie is an icon of Pennsylvania Dutch Country.</p>
     </section>
 

--- a/list.html
+++ b/list.html
@@ -22,6 +22,14 @@
     </nav>
 
     <section class="section">
+      <div class="filters">
+        <label for="state-filter">State:</label>
+        <select id="state-filter"><option>All</option></select>
+        <label for="city-filter">City:</label>
+        <select id="city-filter"><option>All</option></select>
+        <label for="style-filter">Style:</label>
+        <select id="style-filter"><option>All</option></select>
+      </div>
       <table id="shoofly-table">
         <thead>
           <tr>

--- a/map.html
+++ b/map.html
@@ -6,8 +6,7 @@
   <title>Shoofly Map</title>
   <link href="https://fonts.googleapis.com/css2?family=Rubik:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="assets/style.css" />
-  <!-- Google Maps JS API -->
-  <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyCwvqpPxd8wHd5VjN7nO4cD-IYWUQrH6xo"></script>
+  <!-- Google Maps API key is provided via assets/config.js -->
 </head>
 <body>
   <main>
@@ -36,6 +35,7 @@
     &copy; 2025 findshoofly.com. All rights reserved.
   </footer>
 
+  <script src="assets/config.js"></script>
   <script src="assets/map.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load Google Maps API key from an ignored `assets/config.js`
- dynamically inject the Google Maps script at runtime
- add state, city, and style filter selects on the list page
- fix broken image reference on the homepage

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689a64b1dad88332a3e94106b4a5549c